### PR TITLE
Removed conditional request style from credential registration

### DIFF
--- a/Sources/Passage/interfaces/PassageCurrentUser.swift
+++ b/Sources/Passage/interfaces/PassageCurrentUser.swift
@@ -170,8 +170,7 @@ final public class PassageCurrentUser {
             let authController = PasskeyAuthenticationController()
             let credential = try await authController.requestPasskeyRegistration(
                 registrationRequest: registrationRequest,
-                includeSecurityKeyOption: includeSecurityKeyOption,
-                autoUpgradeAccount: options?.isConditionalMediation == true
+                includeSecurityKeyOption: includeSecurityKeyOption
             )
             // Send the new Credential Handshake Response to Passage server
             let finishRequest = RegisterWebAuthnFinishRequest(

--- a/Sources/Passage/services/passkeyAuthentication/PasskeyAuthorizationController.swift
+++ b/Sources/Passage/services/passkeyAuthentication/PasskeyAuthorizationController.swift
@@ -12,31 +12,17 @@ internal class PasskeyAuthenticationController:
     
     internal func requestPasskeyRegistration(
         registrationRequest: PasskeyRegistrationRequest,
-        includeSecurityKeyOption: Bool = false,
-        autoUpgradeAccount: Bool = false
+        includeSecurityKeyOption: Bool = false
     ) async throws -> ASAuthorizationPublicKeyCredentialRegistration {
         let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(
             relyingPartyIdentifier: registrationRequest.relyingPartyIdentifier
         )
-        var platformRegistrationRequest = publicKeyCredentialProvider
+        let platformRegistrationRequest = publicKeyCredentialProvider
             .createCredentialRegistrationRequest(
                 challenge: registrationRequest.challenge,
                 name: registrationRequest.userName,
                 userID: registrationRequest.userId
             )
-        #if os(iOS) || os(macOS) || os(visionOS)
-        if #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) {
-            if autoUpgradeAccount {
-                platformRegistrationRequest = publicKeyCredentialProvider
-                    .createCredentialRegistrationRequest(
-                        challenge: registrationRequest.challenge,
-                        name: registrationRequest.userName,
-                        userID: registrationRequest.userId,
-                        requestStyle: .conditional
-                    )
-            }
-        }
-        #endif
         // To match other webauthn "cross-platform" behaviors, we always include a Platform provider
         // request, never JUST a Security Key provider request.
         var requests: [ASAuthorizationRequest] = [ platformRegistrationRequest ]

--- a/Sources/Passage/services/passkeyAuthentication/PasskeyCreationOptions.swift
+++ b/Sources/Passage/services/passkeyAuthentication/PasskeyCreationOptions.swift
@@ -7,18 +7,8 @@ public struct PasskeyCreationOptions {
     /// Set to `.crossPlatform` to provide option for user  to store credential on a physical Security Key.
     public let authenticatorAttachment: AuthenticatorAttachment?
     
-    /// Set to `true` to create a passkey without asking the user.
-    ///
-    /// NOTE: Only available on iOS 18.0+, macOS 15.0+, and visionOS 2.0+.
-    public let isConditionalMediation: Bool?
-    
-    public init(authenticatorAttachment: AuthenticatorAttachment?, isConditionalMediation: Bool?) {
+    public init(authenticatorAttachment: AuthenticatorAttachment?) {
         self.authenticatorAttachment = authenticatorAttachment
-        if #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) {
-            self.isConditionalMediation = isConditionalMediation
-        } else {
-            self.isConditionalMediation = false
-        }
     }
     
 }


### PR DESCRIPTION
## What's New?

Removed conditional request style from credential registration.
Reasons:
* only supported in Xcode 16 and newer (which is only days old)
* to match registration options on other Passage client sdks

## Screenshots (if appropriate):

NA


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have manually tested my code thoroughly
- [x] I have added/updated inline documentation for public facing interfaces if relevant
- [x] My changes generate no new warnings
- [x] New and existing integration and unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


## Jira Ticket

Please add the Jira ticket number and link.

- [x] Jira Ticket: [PSG-4773](https://passage-identity.atlassian.net/browse/PSG-4773)



[PSG-4773]: https://passage-identity.atlassian.net/browse/PSG-4773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ