### PR TITLE
Set Cocoapod module name to Passage instead of PassageSwift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7e98e0c0713867f950e25ec1449eb07b639fe756ca08d6d5f949fda33c8fa967",
+  "originHash" : "fd6f2919a6beae8573b7edd484b251a4d01d37ca02c6a7f36527f0f3c797a195",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "69261f239f0fffaf51495dadc4f8483fbfe97025",
         "version" : "0.6.1"
+      }
+    },
+    {
+      "identity" : "passage-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/passageidentity/passage-swift",
+      "state" : {
+        "revision" : "4b9b700f731a6cabb91524da91fa775636adf491",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/PassageSwift.podspec
+++ b/PassageSwift.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'PassageSwift'
-  s.version          = ENV['LIB_VERSION'] || '1.0.0'
+  s.module_name      = 'Passage'
+  s.version          = ENV['LIB_VERSION'] || '1.0.1'
   s.summary          = 'Use Passage Authentication in your iOS application'
   s.homepage         = 'https://github.com/passageidentity/passage-swift'
   s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
@@ -8,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/passageidentity/passage-swift.git', :tag => s.version.to_s }
   s.ios.deployment_target = "14.0"
   s.osx.deployment_target = "12.0"
-  s.tvos.deployment_target = "14.0"
+  # s.tvos.deployment_target = "14.0"
   # s.watchos.deployment_target = "7.0"
   # s.visionos.deployment_target = "1.0"
   s.swift_version = '5.0'

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 # Passage Swift
 
 ![SPM Version](https://img.shields.io/github/v/release/passageidentity/passage-swift?style=flat&label=Swift%20Package)
-<!---
 ![Cocoapods Version](https://img.shields.io/github/v/release/passageidentity/passage-swift?style=flat&label=CocoaPods)
--->
 
 ![Language](https://img.shields.io/badge/Swift-informational?style=flat&logo=swift&logoColor=white&color=FA7343)
 ![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fpassage-swift%2Fpassage-swift%2Fbadge%3Ftype%3Dplatforms)
@@ -20,13 +18,12 @@ To install via Swift Package Manager, enter this url Xcode's Swift Package Manag
 ```
 https://github.com/passageidentity/passage-swift
 ```
-<!---
+
 ### CocoaPods
 To install via Cocoapods, add this dependency to your Podfile:
 ``` ruby
 pod 'PassageSwift'
 ```
--->
 
  <br />
 


### PR DESCRIPTION
## What's New?
Set Cocoapod module name to Passage instead of PassageSwift


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have manually tested my code thoroughly
- [x] I have added/updated inline documentation for public facing interfaces if relevant
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing integration and unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

